### PR TITLE
fix a bug of input embedding dimension in regal

### DIFF
--- a/regal/regal.py
+++ b/regal/regal.py
@@ -129,6 +129,7 @@ def learn_representations(args):
                             normalize = True, 
                             gammastruc = args.gammastruc, 
                             gammaattr = args.gammaattr)
+    rep_method.p = args.dimensions
     if max_layer is None:
         max_layer = 1000
     print("Learning representations with max layer %d and alpha = %f" % (max_layer, alpha))


### PR DESCRIPTION
In the implementation of regal, the input dimension args.dimensions is left unused and the program fails to generate node embeddings according to args.dimensions. After adding the line
rep_method.p = args.dimensions
the bug is fixed.